### PR TITLE
Improve Overview dialog

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -56,9 +56,9 @@ class HeaderBar(Gtk.HeaderBar):
 
     def _on_overview_button(self, button):
         """Callback for overview button."""
-        # [FIXME] Make sure only one overview dialog is shown at a time.
-        overview = OverviewScreen(self._parent._app, self._parent)
-        overview.show_all()
+        if not self._parent._overview_window:
+            self._parent._overview_window = OverviewScreen(self._parent, self._parent._app)
+        self._parent._overview_window.present()
 
 
 class MainWindow(Gtk.ApplicationWindow):
@@ -80,6 +80,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # Some basic inventory
         self._app = app
+        self._overview_window = None
 
         # Some Geometry
         self.set_default_size(*DEFAULT_WINDOW_SIZE)

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -62,3 +62,15 @@ def show_error(parent, error, message=None):
     dialog = dialogs.ErrorDialog(parent, message)
     dialog.run()
     dialog.destroy()
+
+
+def clear_children(widget):
+    """
+    Remove and destroy all children from a widget.
+
+    It seems GTK really does not have this build in. Iterating over all
+    seems a bit blunt, but seems to be the way to do this.
+    """
+    for child in widget.get_children():
+        child.destroy()
+    return widget


### PR DESCRIPTION
``OverviewScreen`` now provides a ``refresh`` method that triggers
recomputation of facts as well as a redrawing of all widgets.
For now, we go without signals and just call this method as needed.
If it turns out we actually need signals it can easily be extended.

We also changed ``hamster_gtk.HeaderBar._on_overview_button`` to reuse
an already existing dialog. However, as we ran into problems with
hiding/re-showing a once instantiated OverviewScreen class for unknown
reasons we destroy our ``OverviewScreen`` when closed entirely. As a
consequence a new one will be generated if ``_on_overview_button`` is
called again.